### PR TITLE
ci: prevent PR CI duplicate builds

### DIFF
--- a/.github/workflows/build-softsim-lib.yml
+++ b/.github/workflows/build-softsim-lib.yml
@@ -3,7 +3,7 @@ name: Build SoftSIM Library
 on:
   push:
     branches:
-      - "**"
+      - master
   pull_request:
 
 concurrency:


### PR DESCRIPTION
The build for the SoftSIM library will now only trigger on pushes to the `master` branch, instead of all branches, reducing duplicate build when a PR is opened.