### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/build-softsim-lib.yml
+++ b/.github/workflows/build-softsim-lib.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   onomondo-uicc-build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   clang-format:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr_commit_checks.yml
+++ b/.github/workflows/pr_commit_checks.yml
@@ -3,6 +3,9 @@ name: PR Commit Checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pr-commit-checks:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Follows GitHub Actions security hardening best practices. GITHUB_TOKEN defaults to write-all without explicit permissions.