### PR TITLE
ci: pin dependecies to full-length SHA

### DIFF
--- a/.github/workflows/build-softsim-lib.yml
+++ b/.github/workflows/build-softsim-lib.yml
@@ -17,18 +17,18 @@ jobs:
 
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
         with:
           cmakeVersion: 3.27.0
           ninjaVersion: 1.11.1
 
       - name: Install Embedded Toolchain
-        uses: carlosperate/arm-none-eabi-gcc-action@v1.11.1
+        uses: carlosperate/arm-none-eabi-gcc-action@4c88c61a77a39a33a7722d24a4e8b2c573f766c9 # v1.11.1
 
       - name: Apply patches to onomondo-uicc
         working-directory: onomondo-uicc

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install clang-format
         run: sudo apt-get update && sudo apt-get install -y clang-format

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           release-type: simple


### PR DESCRIPTION
Want to enable 'Require actions to be pinned to a full-length commit SHA' going forward and let Renovate handle the rest.