### PR TITLE
chore: collapse Dockerfile RUN layers and clean apt cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM --platform=linux/amd64 ubuntu:24.04
 
-RUN apt update
-RUN apt upgrade -y
-RUN apt install -y python3 sudo libglib2.0-0 wget make git
-
-RUN wget http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu55_55.1-7_amd64.deb && dpkg -i libicu55_55.1-7_amd64.deb && rm libicu55_55.1-7_amd64.deb
+RUN apt update && \
+  apt upgrade -y && \
+  apt install -y python3 sudo libglib2.0-0 wget make git && \
+  rm -rf /var/lib/apt/lists/* && \
+  wget https://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu55_55.1-7_amd64.deb && \
+  dpkg -i libicu55_55.1-7_amd64.deb && \
+  rm libicu55_55.1-7_amd64.deb


### PR DESCRIPTION
- Collapse four separate `RUN` layers into one, ensuring the apt cache
  is removed in the same layer it is created (previously the cache was
  committed to an intermediate layer, bloating the image)
- Fetch `libicu55` over HTTPS instead of HTTP