### PR TITLE
ci: remove 200 from accepted status list of markdown link checker

### DIFF
--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           fail: true
           # Accept 403 (Forbidden) and 429 (rate limit) to avoid false positives
-          args: --accept "200,403,429" --verbose --no-progress './**/*.md'
+          args: --accept "403,429" --verbose --no-progress './**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Saw some false positive errors on 200.

- Remove 200 from Lychee accepted status list (200 is normal success)
- Keep 403 and 429 accepted to avoid false positives from forbidden or rate-limited endpoints