### PR TITLE
ci: bump onomondo-uicc only on release tags

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,8 +32,7 @@
       "matchManagers": [
         "github-actions"
       ],
-      "groupName": "github-actions",
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
@@ -46,6 +45,13 @@
         "pinDigest"
       ],
       "minimumReleaseAge": null
+    },
+    {
+      "description": "onomondo-uicc is pinned to a release tag via the .gitmodules branch field, so only accept refs shaped like a release. The git-refs datasource returns branches and tags in one list, so without this a tag-like branch name could move the pin to an unreleased HEAD.",
+      "matchManagers": [
+        "git-submodules"
+      ],
+      "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+$/"
     }
   ]
 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "onomondo-uicc"]
 	path = onomondo-uicc
 	url = git@github.com:onomondo/onomondo-uicc.git
+	branch = v2.2.1


### PR DESCRIPTION
Moves the pin off an untagged master commit to v2.2.1 (21 commits, no breaking changes) and records the tag as the submodule branch, so Renovate bumps on a new release instead of tracking master HEAD. Renovate config aligned with nrf-softsim.

Note `git submodule update --remote` no longer works; use `--init --recursive`.